### PR TITLE
Use fully-qualified type class name instead of alias.

### DIFF
--- a/Form/Extension/GeoCodeExtension.php
+++ b/Form/Extension/GeoCodeExtension.php
@@ -19,7 +19,7 @@ class GeoCodeExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return 'form';
+        return FormType::class;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -47,4 +47,4 @@ services:
         class: %pugx_geo_form.geo_code_type_extension_class%
         arguments: ["@pugx_geo_form.geo_form_type_subscriber"]
         tags:
-            - { name: form.type_extension, alias: form }
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }


### PR DESCRIPTION
Part of the effort to remove depreciated features to enable easier upgrade to symfony 3.0.
